### PR TITLE
add chenge mode

### DIFF
--- a/gnss_navigation/gnss_navigation/gnss_path_follower.cpp
+++ b/gnss_navigation/gnss_navigation/gnss_path_follower.cpp
@@ -46,8 +46,8 @@ private:
     void followPath() {
         if (path_.empty() || !autonomous_flag_) {
             geometry_msgs::msg::Vector3 cmd_vel;
-            cmd_vel.linear.x = 0;
-            cmd_vel.angular.z = 0;
+            cmd_vel.x = 0;
+            cmd_vel.z = 0;
             cmd_pub_->publish(cmd_vel);
             RCLCPP_INFO(this->get_logger(), "Autonomous mode is off or path is empty. Stopping the robot.");
             return;
@@ -96,8 +96,8 @@ private:
             double controlled_linear_speed = std::min(max_linear_velocity_, k_p_linear_ * distance_to_lookahead);
             double controlled_angular_speed = std::copysign(std::min(std::abs(angle_difference), max_angular_velocity_), angle_difference);
 
-            cmd_vel.linear.x = controlled_linear_speed;
-            cmd_vel.angular.z = controlled_angular_speed;
+            cmd_vel.x = controlled_linear_speed;
+            cmd_vel.z = controlled_angular_speed;
 
         if(autonomous_flag_ == true)
         cmd_pub_->publish(cmd_vel);

--- a/gnss_navigation/gnss_navigation/gnss_path_follower.cpp
+++ b/gnss_navigation/gnss_navigation/gnss_path_follower.cpp
@@ -91,7 +91,7 @@ private:
 
         RCLCPP_INFO(this->get_logger(), "Current distance to target: %f meters, Current angle to target: %f radians", distance_to_lookahead, angle_difference);
 
-        geometry_msgs::msg::Twist cmd_vel;
+        geometry_msgs::msg::Vector3 cmd_vel;
             RCLCPP_INFO(this->get_logger(), "Autonomous mode is off. Stopping the robot.");
             double controlled_linear_speed = std::min(max_linear_velocity_, k_p_linear_ * distance_to_lookahead);
             double controlled_angular_speed = std::copysign(std::min(std::abs(angle_difference), max_angular_velocity_), angle_difference);


### PR DESCRIPTION
gnss_navigationのgnss_path_followerにおいて速度指令値を送る際にコントローラーで切り替えるモードを参照するようにした.
自律モード以外では速度指令値をパブリッシュしないようになっている.