### PR TITLE
✨feat:vectornav,simflagの追加

### DIFF
--- a/main_executor/config/main_params.yaml
+++ b/main_executor/config/main_params.yaml
@@ -11,13 +11,13 @@ launch: #起動パラメータ
 
     # 並進  速度[m/s],加速度[m/s^2],加減速度[-m/s^2],躍度[m/s^3]
     linear_max:
-      vel : 1.5
-      acc: 2.0
+      vel : 3.0
+      acc: 9.0
       jer: 0.0
     # 回転  速度[deg/s],加速度[deg/s^2],加減速度[-deg/s^2],躍度[deg/s^3]
     angular_max :
-      vel: 30.0
-      acc: 40.0
+      vel: 60.0
+      acc: 180.0
       jer: 0.0
 
     tread : 0.6
@@ -60,14 +60,15 @@ cybergear_interface_node:
 
 path_publisher_node:
   ros__parameters:
-    interval_ms : 100
-    path_file_name : "gazebo_shihou_course"
+    interval_ms : 1000
+    path_file_name : "shihou_gnssnav"
 
 gnssnav_follower_node:
   ros__parameters:
-    interval_ms : 100
+    debug_flag : false
+    interval_ms : 50
     lookahead_gain : 1.0
-    cte_gain : 1.0
+    cte_gain : 1.5
     min_lookahead_distance : 3.0
-    max_linear_vel : 1.0
-    max_angular_vel : 1.0
+    max_linear_vel : 2.0
+    max_angular_vel : 1.5

--- a/main_executor/launch/main_exec.launch.py
+++ b/main_executor/launch/main_exec.launch.py
@@ -4,6 +4,8 @@ import yaml
 import launch
 from launch import LaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from ament_index_python.packages import get_package_share_directory
 from launch_ros.actions import Node
 
@@ -25,11 +27,30 @@ def generate_launch_description():
     with open(config_file_path, 'r') as file:
         launch_params = yaml.safe_load(file)['launch']['ros__parameters']
 
+
+    # メイン実行機のログレベルの設定
+    log_level = LaunchConfiguration("log_level")
+    # デフォルトのログレベルを'info'に設定
+    log_level_arg = DeclareLaunchArgument(
+        "log_level",
+        default_value=["info"],
+        description="Logging level",
+    )
+    # メイン実行機のシミュレータ環境の設定
+    sim_flag = LaunchConfiguration("sim_flag")
+    # デフォルトのシミュレータ環境を'false'に設定
+    sim_flag_arg = DeclareLaunchArgument(
+        "sim_flag",
+        default_value=["false"],
+        description="Use simulator or not",
+    )
+
     # メイン実行機ノードの作成
     main_exec_node = Node(
         package = 'main_executor',
         executable = 'main_exec',
         parameters = [config_file_path],
+        arguments=["--sim-flag", sim_flag, "--ros-args", "--log-level", log_level],
         output='screen'
     )
 
@@ -40,6 +61,13 @@ def generate_launch_description():
         output='screen'
     )
 
+    # vectornav起動の作成
+    vectornav_launch = launch.actions.IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+            get_package_share_directory('vectornav'), 'launch/'),
+            'vectornav.launch.py'])
+    )
+
     # 起動エンティティクラスの作成
     launch_discription = LaunchDescription()
 
@@ -48,7 +76,11 @@ def generate_launch_description():
         subprocess.run(['sudo', 'sh', can_launch_path])
     if(launch_params['joy'] is True):
         launch_discription.add_entity(joy_node)
+    if(launch_params['vectornav'] is True):
+        launch_discription.add_action(vectornav_launch)
 
+    launch_discription.add_action(log_level_arg)
+    launch_discription.add_action(sim_flag_arg)
     launch_discription.add_entity(main_exec_node)
 
     return launch_discription

--- a/main_executor/src/main.cpp
+++ b/main_executor/src/main.cpp
@@ -15,6 +15,14 @@ int main(int argc, char * argv[]){
     nodes_option.allow_undeclared_parameters(true);
     nodes_option.automatically_declare_parameters_from_overrides(true);
 
+    bool sim_flag = false;
+    for(int i = 0; i < argc; ++i){
+        if(std::string(argv[i])=="--sim-flag"){
+            if(std::string(argv[i+1])=="true") sim_flag = true;
+            break;
+        }
+    }
+
     auto socketcan_node = std::make_shared<socketcan_interface::SocketcanInterface>(nodes_option);
     auto socketcan_cybergear_node = std::make_shared<socketcan_interface::SocketcanInterface>("cybergear", nodes_option);
     auto controller_node = std::make_shared<controller::Controller>(nodes_option);
@@ -23,8 +31,11 @@ int main(int argc, char * argv[]){
     auto path_publisher_node = std::make_shared<gnssnav::Publisher>(nodes_option);
     auto follower_node = std::make_shared<gnssnav::Follower>(nodes_option);
 
-    exec.add_node(socketcan_node);
-    exec.add_node(socketcan_cybergear_node);
+    if(sim_flag){}
+    if(not sim_flag){
+        exec.add_node(socketcan_node);
+        exec.add_node(socketcan_cybergear_node);
+    }
     exec.add_node(controller_node);
     exec.add_node(chassis_driver_node);
     exec.add_node(cybergear_interface_node);


### PR DESCRIPTION
## 起動の設定
起動パラメータをlaunch引数を使用して設定する．
### 通常の起動（実機での起動）
```
ros2 launch main_executor main_exec.launch.py
```
### シミュレータ環境での起動
```
ros2 launch main_executor main_exec.launch.py sim_flag:=true
```
※インスタンス化自体はされるので，socketcanのバインドエラーなどは出る<-問題はない

### ログレベルを指定した起動
```
ros2 launch main_executor main_exec.launch.py log_level:=info
ros2 launch main_executor main_exec.launch.py log_level:=20
ros2 launch main_executor main_exec.launch.py sim_flag:=true log_level:=info
```

## 起動の追加
こちらは`ros__parameters`（ノードパラメータの記載）となっているが，現状の実装はpythonでyamlを読み込んでいるだけ．
https://github.com/open-rdc/aiformula/blob/launch/main_executor/config/main_params.yaml
```yaml
launch: #起動パラメータ
  ros__parameters:
    can: false #socketcanをsetupするか
    joy: false #joy_nodeを立ち上げるか
    vectornav : false #vectornavを立ち上げるか

・・・
```

---
- [ROS2におけるパラメータ](https://zenn.dev/uedake/articles/ros2_concept3_parameters)
- [log level](https://docs.ros.org/en/foxy/Tutorials/Demos/Logging-and-logger-configuration.html)
