### PR TITLE
vectornav/poseとgnssで内容の違いがあるかの検証

### DIFF
--- a/gnssnav/CMakeLists.txt
+++ b/gnssnav/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
@@ -51,6 +52,23 @@ ament_target_dependencies(
   utilities
 )
 target_link_libraries(navigation_node ${PROJ_LIBRARY})
+
+
+# 実行可能ノード
+add_executable(vectornav_debug
+  src/vectornav_debug.cpp
+)
+target_include_directories(vectornav_debug PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+ament_target_dependencies(vectornav_debug
+  rclcpp
+  geometry_msgs
+  sensor_msgs
+  utilities
+)
+target_link_libraries(vectornav_debug ${PROJ_LIBRARY})
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -92,6 +110,11 @@ install(
 
 install(DIRECTORY config
  DESTINATION share/${PROJECT_NAME}
+)
+
+install(
+  TARGETS vectornav_debug
+  DESTINATION lib/${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)

--- a/gnssnav/src/vectornav_debug.cpp
+++ b/gnssnav/src/vectornav_debug.cpp
@@ -1,0 +1,88 @@
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <sensor_msgs/msg/nav_sat_fix.hpp>
+
+#include <proj.h>
+
+class VectorvavSubscriber : public rclcpp::Node{
+public:
+    explicit VectorvavSubscriber(): Node("vectornav_subscriber"){
+        pose_subscription_ = this->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
+            "vectornav/pose",
+            10,
+            std::bind(&VectorvavSubscriber::pose_callback, this, std::placeholders::_1));
+
+        gnss_subscription_ = this->create_subscription<sensor_msgs::msg::NavSatFix>(
+            "vectornav/gnss",
+            10,
+            std::bind(&VectorvavSubscriber::gnss_callback, this, std::placeholders::_1));
+
+        ecef_proj = proj_create_crs_to_crs(PJ_DEFAULT_CTX,
+            "EPSG:4978", // ECEF
+            "EPSG:32654", // UTMゾーン54N
+            nullptr);
+        gps_proj = proj_create_crs_to_crs(PJ_DEFAULT_CTX,
+            "EPSG:4326",    // GPS
+            "EPSG:32654",   // UTMゾーン54N
+            nullptr);
+
+        RCLCPP_INFO(this->get_logger(), "VectorNavSubscriber node initialized.");
+    }
+    ~VectorvavSubscriber(){
+        proj_destroy(ecef_proj);
+        proj_destroy(gps_proj);
+    }
+
+private:
+    void pose_callback(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg){
+        auto [x, y] = convertECEFtoUTM(msg->pose.pose.position.x, msg->pose.pose.position.y, msg->pose.pose.position.z);
+        RCLCPP_INFO(this->get_logger(), "pose:[x: %.2f, y: %.2f]", x, y);
+        RCLCPP_INFO(this->get_logger(), "--------------------------------");
+
+    }
+
+    void gnss_callback(const sensor_msgs::msg::NavSatFix::SharedPtr msg){
+        auto [x, y] = convertGPStoUTM(msg->latitude, msg->longitude);
+        RCLCPP_INFO(this->get_logger(), "gnss:[x: %.2f, y: %.2f]", x, y);
+    }
+
+
+    std::pair<double, double> convertECEFtoUTM(const double x, const double y, const double z){
+        if(ecef_proj == nullptr) {
+            std::cerr << "ECEF PROJ error!" << std::endl;
+        }
+        PJ_COORD a, b;
+
+        a.xyz.x = x;
+        a.xyz.y = y;
+        a.xyz.z = z;
+
+        b = proj_trans(ecef_proj, PJ_FWD, a);
+
+        return {b.enu.e, b.enu.n};
+    }
+    std::pair<double, double> convertGPStoUTM(const double lat, const double lon) {
+        if(gps_proj == nullptr) {
+            std::cerr << "GPS PROJ error!" << std::endl;
+        }
+        if (!(-90.0 <= lat) || !(lat <= 90.0) || !(-180.0 <= lon) || !(lon <= 180.0)) {
+            std::cerr << "Latitude or longitude range error!" << std::endl;
+            return {std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()};
+        }
+        PJ_COORD p = proj_coord(lat, lon, 0, 0);
+        p = proj_trans(gps_proj, PJ_FWD, p);
+        return {p.xy.x, p.xy.y};
+    }
+
+    rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pose_subscription_;
+    rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr gnss_subscription_;
+
+    PJ *gps_proj, *ecef_proj;
+};
+
+int main(int argc, char **argv){
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<VectorvavSubscriber>());
+    rclcpp::shutdown();
+    return 0;
+}

--- a/utilities/include/utilities/position_pid.hpp
+++ b/utilities/include/utilities/position_pid.hpp
@@ -7,7 +7,7 @@ public:
     PositionPid(const int sampling_time_ms): sampling_time(static_cast<double>(sampling_time_ms)/1000.0){}
     double cycle(double current_pos, double target_pos){
         double error = target_pos - current_pos;
-        cycle(error);
+        return cycle(error);
     }
     double cycle(double error){
         error_ = error;


### PR DESCRIPTION
結論：ない

以下はそれぞれをUTMに変換して表示したもの．
https://github.com/open-rdc/aiformula/issues/134
この問題はその他が起因していると考えられる．
```
[INFO] [1737201559.181846662] [vectornav_subscriber]: gnss:[x: 408339.62, y: 3997005.95]
[INFO] [1737201559.238458186] [vectornav_subscriber]: pose:[x: 408339.62, y: 3997005.95]
[INFO] [1737201559.238549970] [vectornav_subscriber]: --------------------------------
[INFO] [1737201559.238603406] [vectornav_subscriber]: gnss:[x: 408339.67, y: 3997005.95]
[INFO] [1737201559.281826534] [vectornav_subscriber]: pose:[x: 408339.67, y: 3997005.95]
[INFO] [1737201559.282035609] [vectornav_subscriber]: --------------------------------
[INFO] [1737201559.282222718] [vectornav_subscriber]: gnss:[x: 408339.72, y: 3997005.96]
[INFO] [1737201559.332059321] [vectornav_subscriber]: pose:[x: 408339.72, y: 3997005.96]
[INFO] [1737201559.332230049] [vectornav_subscriber]: --------------------------------
[INFO] [1737201559.332432743] [vectornav_subscriber]: gnss:[x: 408339.78, y: 3997005.96]
[INFO] [1737201559.382090596] [vectornav_subscriber]: pose:[x: 408339.78, y: 3997005.96]
[INFO] [1737201559.382179785] [vectornav_subscriber]: --------------------------------
[INFO] [1737201559.382251548] [vectornav_subscriber]: gnss:[x: 408339.82, y: 3997005.95]
[INFO] [1737201559.431701121] [vectornav_subscriber]: pose:[x: 408339.82, y: 3997005.95]
[INFO] [1737201559.431789336] [vectornav_subscriber]: --------------------------------
[INFO] [1737201559.431859096] [vectornav_subscriber]: gnss:[x: 408339.87, y: 3997005.96]
[INFO] [1737201559.482202217] [vectornav_subscriber]: pose:[x: 408339.87, y: 3997005.96]
[INFO] [1737201559.482288591] [vectornav_subscriber]: --------------------------------
[INFO] [1737201559.482353138] [vectornav_subscriber]: gnss:[x: 408339.92, y: 3997005.96]
[INFO] [1737201559.531481392] [vectornav_subscriber]: pose:[x: 408339.92, y: 3997005.96]
[INFO] [1737201559.531561750] [vectornav_subscriber]: --------------------------------
[INFO] [1737201559.531638236] [vectornav_subscriber]: gnss:[x: 408339.97, y: 3997005.96]
[INFO] [1737201559.588214440] [vectornav_subscriber]: pose:[x: 408339.97, y: 3997005.96]
[INFO] [1737201559.588302822] [vectornav_subscriber]: --------------------------------
[INFO] [1737201559.588380077] [vectornav_subscriber]: gnss:[x: 408340.01, y: 3997005.97]
[INFO] [1737201559.632674514] [vectornav_subscriber]: pose:[x: 408340.01, y: 3997005.97]
[INFO] [1737201559.632783938] [vectornav_subscriber]: --------------------------------
[INFO] [1737201559.632878616] [vectornav_subscriber]: gnss:[x: 408340.06, y: 3997005.97]
[INFO] [1737201559.681557917] [vectornav_subscriber]: pose:[x: 408340.06, y: 3997005.97]
[INFO] [1737201559.681700103] [vectornav_subscriber]: --------------------------------
[INFO] [1737201559.681767527] [vectornav_subscriber]: gnss:[x: 408340.10, y: 3997005.97]
[INFO] [1737201559.732321323] [vectornav_subscriber]: pose:[x: 408340.10, y: 3997005.97]
[INFO] [1737201559.732491920] [vectornav_subscriber]: --------------------------------
[INFO] [1737201559.732638474] [vectornav_subscriber]: gnss:[x: 408340.15, y: 3997005.98]
[INFO] [1737201559.781910402] [vectornav_subscriber]: pose:[x: 408340.15, y: 3997005.98]
[INFO] [1737201559.782132661] [vectornav_subscriber]: --------------------------------
[INFO] [1737201559.782281992] [vectornav_subscriber]: gnss:[x: 408340.18, y: 3997006.00]
[INFO] [1737201559.831794940] [vectornav_subscriber]: pose:[x: 408340.18, y: 3997006.00]
[INFO] [1737201559.831959829] [vectornav_subscriber]: --------------------------------
[INFO] [1737201559.832105390] [vectornav_subscriber]: gnss:[x: 408340.23, y: 3997006.01]
[INFO] [1737201559.881353010] [vectornav_subscriber]: pose:[x: 408340.23, y: 3997006.01]
[INFO] [1737201559.881441976] [vectornav_subscriber]: --------------------------------
[INFO] [1737201559.881513842] [vectornav_subscriber]: gnss:[x: 408340.27, y: 3997006.01]
[INFO] [1737201559.937182959] [vectornav_subscriber]: pose:[x: 408340.27, y: 3997006.01]
[INFO] [1737201559.937278118] [vectornav_subscriber]: --------------------------------
[INFO] [1737201559.937354065] [vectornav_subscriber]: gnss:[x: 408340.32, y: 3997006.01]
[INFO] [1737201559.981846695] [vectornav_subscriber]: pose:[x: 408340.32, y: 3997006.01]
[INFO] [1737201559.982013250] [vectornav_subscriber]: --------------------------------
[INFO] [1737201559.982086418] [vectornav_subscriber]: gnss:[x: 408340.37, y: 3997006.02]
[INFO] [1737201560.031717303] [vectornav_subscriber]: pose:[x: 408340.37, y: 3997006.02]
[INFO] [1737201560.031892957] [vectornav_subscriber]: --------------------------------
[INFO] [1737201560.031970126] [vectornav_subscriber]: gnss:[x: 408340.42, y: 3997006.02]
[INFO] [1737201560.082308947] [vectornav_subscriber]: pose:[x: 408340.42, y: 3997006.02]
```