### PR TITLE
Improve lookahead target selection in PurePursuitFollower

### DIFF
--- a/visual_odometry/include/visual_odometry/vo_follower_node.hpp
+++ b/visual_odometry/include/visual_odometry/vo_follower_node.hpp
@@ -18,6 +18,7 @@
 #include <vector>
 #include <cmath>
 #include <memory>
+#include <limits>
 
 namespace vonav
 {

--- a/visual_odometry/src/vo_follower_node.cpp
+++ b/visual_odometry/src/vo_follower_node.cpp
@@ -104,10 +104,25 @@ void PurePursuitFollower::findLookaheadPoint()
 {
     double lookahead = ld_gain_ * v_max_ + ld_min_;
 
+    size_t closest_idx = prev_idx_;
+    double closest_dist = std::numeric_limits<double>::infinity();
     for (size_t i = prev_idx_; i < path_.size(); ++i) {
-        double dx = path_[i].pose.position.x - current_x_;
-        double dy = path_[i].pose.position.y - current_y_;
-        double dist = std::hypot(dx, dy);
+        const double dx = path_[i].pose.position.x - current_x_;
+        const double dy = path_[i].pose.position.y - current_y_;
+        const double dist = std::hypot(dx, dy);
+
+        if (dist < closest_dist) {
+            closest_dist = dist;
+            closest_idx = i;
+        }
+    }
+
+    prev_idx_ = closest_idx;
+
+    for (size_t i = closest_idx; i < path_.size(); ++i) {
+        const double dx = path_[i].pose.position.x - current_x_;
+        const double dy = path_[i].pose.position.y - current_y_;
+        const double dist = std::hypot(dx, dy);
 
         if (dist > lookahead) {
             target_idx_ = i;


### PR DESCRIPTION
### Motivation
- Prevent steering toward stale points by starting the lookahead search from the path point closest to the robot (ahead) instead of continuing from an outdated `prev_idx_`.

### Description
- Update `findLookaheadPoint()` to first scan from `prev_idx_` to find the closest path index, set `prev_idx_` to that closest index, and then search forward from that index for the first point whose distance is greater than the computed lookahead to set `target_idx_`.
- Add `#include <limits>` to enable initialization of the closest-distance search with `std::numeric_limits<double>::infinity()`.
- Modified files: `visual_odometry/src/vo_follower_node.cpp` and `visual_odometry/include/visual_odometry/vo_follower_node.hpp`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696761f837b88325a02f9cb9b5835fd5)