### PR TITLE
use_intra_process_commsの有効化

### DIFF
--- a/chassis_driver/chassis_driver/include/chassis_driver/chassis_driver_node.hpp
+++ b/chassis_driver/chassis_driver/include/chassis_driver/chassis_driver_node.hpp
@@ -34,12 +34,12 @@ private:
     rclcpp::Subscription<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr _subscription_bodyvel;
     rclcpp::TimerBase::SharedPtr _pub_timer;
 
-    void _subscriber_callback_vel(const steered_drive_msg::msg::SteeredDrive::SharedPtr msg);
-    void _subscriber_callback_restart(const std_msgs::msg::Empty::SharedPtr msg);
-    void _subscriber_callback_caster_orientation(const socketcan_interface_msg::msg::SocketcanIF::SharedPtr msg);
-    void _subscriber_callback_caster_rotation(const socketcan_interface_msg::msg::SocketcanIF::SharedPtr msg);
-    void _subscriber_callback_emergency(const socketcan_interface_msg::msg::SocketcanIF::SharedPtr msg);
-    void _subscriber_callback_bodyvel(const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg);
+    void _subscriber_callback_vel(const steered_drive_msg::msg::SteeredDrive::ConstSharedPtr msg);
+    void _subscriber_callback_restart(const std_msgs::msg::Empty::ConstSharedPtr msg);
+    void _subscriber_callback_caster_orientation(const socketcan_interface_msg::msg::SocketcanIF::ConstSharedPtr msg);
+    void _subscriber_callback_caster_rotation(const socketcan_interface_msg::msg::SocketcanIF::ConstSharedPtr msg);
+    void _subscriber_callback_emergency(const socketcan_interface_msg::msg::SocketcanIF::ConstSharedPtr msg);
+    void _subscriber_callback_bodyvel(const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr msg);
     void _publisher_callback();
     void send_rpm(const double linear_vel, const double angular_vel);
     static double normalize_angle(double angle);

--- a/chassis_driver/chassis_driver/src/chassis_driver_node.cpp
+++ b/chassis_driver/chassis_driver/src/chassis_driver_node.cpp
@@ -89,7 +89,7 @@ drive_pid(get_parameter("interval_ms").as_int())
         linear_limit.vel, rtod(steering_limit.pos));
 }
 
-void ChassisDriver::_subscriber_callback_vel(const steered_drive_msg::msg::SteeredDrive::SharedPtr msg){
+void ChassisDriver::_subscriber_callback_vel(const steered_drive_msg::msg::SteeredDrive::ConstSharedPtr msg){
     if(mode == Mode::stop) return;
     mode = Mode::cmd;
 
@@ -128,7 +128,7 @@ void ChassisDriver::_publisher_callback(){
         orientation_msg.w = std::cos(odom_yaw * 0.5);
         odom_msg.pose.pose.orientation = orientation_msg;
 
-        publisher_odom->publish(odom_msg);
+        publisher_odom->publish(std::make_unique<nav_msgs::msg::Odometry>(std::move(odom_msg)));
     }
 
 /*速度計画*/
@@ -163,18 +163,18 @@ void ChassisDriver::_publisher_callback(){
     // RCLCPP_INFO(this->get_logger(), "DEL:%.2f POS:%.2f ENC:%.2f", rtod(delta), rtod(motor_pos), rtod(caster_orientation));
 
     // ODriveにトルク指令を送信
-    auto msg_odrive_control = std::make_shared<odrive_can::msg::ControlMessage>();
+    auto msg_odrive_control = std::make_unique<odrive_can::msg::ControlMessage>();
     msg_odrive_control->control_mode = 3;
     msg_odrive_control->input_mode = 1;
     msg_odrive_control->input_pos = motor_pos;
     msg_odrive_control->input_vel = 0.0;
     msg_odrive_control->input_torque = 0.0;
-    publisher_odrive->publish(*msg_odrive_control);
+    publisher_odrive->publish(std::move(msg_odrive_control));
 
     // （テスト用）従動輪{目標舵角，実測舵角，回転位置｝を出版
-    std_msgs::msg::Float64MultiArray caster_data_msg;
-    caster_data_msg.data = {delta, caster_orientation, caster_rotation};
-    publisher_caster_data->publish(caster_data_msg);
+    auto caster_data_msg = std::make_unique<std_msgs::msg::Float64MultiArray>();
+    caster_data_msg->data = {delta, caster_orientation, caster_rotation};
+    publisher_caster_data->publish(std::move(caster_data_msg));
 
 /*駆動輪制御*/
     // 直進時にはプリロードがかかるため，トルク差は0にする
@@ -183,7 +183,7 @@ void ChassisDriver::_publisher_callback(){
     send_rpm(linear_vel, angular_command);
 }
 
-void ChassisDriver::_subscriber_callback_restart(const std_msgs::msg::Empty::SharedPtr msg){
+void ChassisDriver::_subscriber_callback_restart(const std_msgs::msg::Empty::ConstSharedPtr msg){
     mode = Mode::stay;
 
     velplanner::Physics_t physics_zero(0.0, 0.0, 0.0);
@@ -205,7 +205,7 @@ void ChassisDriver::_subscriber_callback_restart(const std_msgs::msg::Empty::Sha
     RCLCPP_INFO(this->get_logger(), "再起動");
 }
 
-void ChassisDriver::_subscriber_callback_caster_orientation(const socketcan_interface_msg::msg::SocketcanIF::SharedPtr msg){
+void ChassisDriver::_subscriber_callback_caster_orientation(const socketcan_interface_msg::msg::SocketcanIF::ConstSharedPtr msg){
     uint8_t _candata[8];
     for(int i=0; i<msg->candlc; i++) _candata[i] = msg->candata[i];
 
@@ -213,7 +213,7 @@ void ChassisDriver::_subscriber_callback_caster_orientation(const socketcan_inte
     caster_orientation = count / static_cast<double>(caster_max_count) * 2.0 * d_pi;
     // RCLCPP_INFO(this->get_logger(), "CAS_ORI:%f CNT:%d", rtod(caster_orientation), count);
 }
-void ChassisDriver::_subscriber_callback_caster_rotation(const socketcan_interface_msg::msg::SocketcanIF::SharedPtr msg){
+void ChassisDriver::_subscriber_callback_caster_rotation(const socketcan_interface_msg::msg::SocketcanIF::ConstSharedPtr msg){
     uint8_t _candata[8];
     for(int i=0; i<msg->candlc; i++) _candata[i] = msg->candata[i];
 
@@ -234,7 +234,7 @@ void ChassisDriver::_subscriber_callback_caster_rotation(const socketcan_interfa
     // RCLCPP_INFO(this->get_logger(), "CAS_ROT:%f CNT:%d", rtod(caster_rotation), count);
     // RCLCPP_INFO(this->get_logger(), "ROT CRR:%f CNT:%d", rtod(current_rotation), count);
 }
-void ChassisDriver::_subscriber_callback_emergency(const socketcan_interface_msg::msg::SocketcanIF::SharedPtr msg){
+void ChassisDriver::_subscriber_callback_emergency(const socketcan_interface_msg::msg::SocketcanIF::ConstSharedPtr msg){
     uint8_t _candata[8];
     for(int i=0; i<msg->candlc; i++) _candata[i] = msg->candata[i];
 
@@ -243,7 +243,7 @@ void ChassisDriver::_subscriber_callback_emergency(const socketcan_interface_msg
         RCLCPP_INFO(this->get_logger(), "緊急停止!");
     }
 }
-void ChassisDriver::_subscriber_callback_bodyvel(const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg){
+void ChassisDriver::_subscriber_callback_bodyvel(const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr msg){
     current_body_vel = msg->twist.twist;
     // RCLCPP_INFO(this->get_logger(), "VEL:%.2f", current_body_vel.linear.x);
 }
@@ -260,7 +260,7 @@ void ChassisDriver::send_rpm(const double linear_vel, const double angular_vel){
 
     // RCLCPP_INFO(this->get_logger(), "right:%f  left:%f", right_rpm, left_rpm);
     // 出版
-    auto msg_can = std::make_shared<socketcan_interface_msg::msg::SocketcanIF>();
+    auto msg_can = std::make_unique<socketcan_interface_msg::msg::SocketcanIF>();
     msg_can->canid = 0x210;
     msg_can->candlc = 8;
 
@@ -269,7 +269,7 @@ void ChassisDriver::send_rpm(const double linear_vel, const double angular_vel){
     int32_to_bytes(_candata+4, static_cast<int32_t>(left_rpm));
 
     for(int i=0; i<msg_can->candlc; i++) msg_can->candata[i]=_candata[i];
-    publisher_can->publish(*msg_can);
+    publisher_can->publish(std::move(msg_can));
 
 }
 

--- a/control/controller/include/controller/controller_node.hpp
+++ b/control/controller/include/controller/controller_node.hpp
@@ -26,7 +26,7 @@ public:
 private:
     rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr _subscription_joy;
 
-    void _subscriber_callback_joy(const sensor_msgs::msg::Joy::SharedPtr msg);
+    void _subscriber_callback_joy(const sensor_msgs::msg::Joy::ConstSharedPtr msg);
     void publish_nav_cmd(const std::string& command);
 
     rclcpp::Publisher<steered_drive_msg::msg::SteeredDrive>::SharedPtr publisher_vel;

--- a/control/controller/src/controller_node.cpp
+++ b/control/controller/src/controller_node.cpp
@@ -29,17 +29,17 @@ steering_max_angle(dtor(get_parameter("steering_max.pos").as_double()))
     // publisher_restart->publish(*std::make_shared<std_msgs::msg::Empty>());
 }
 
-void Controller::_subscriber_callback_joy(const sensor_msgs::msg::Joy::SharedPtr msg){
+void Controller::_subscriber_callback_joy(const sensor_msgs::msg::Joy::ConstSharedPtr msg){
     // 自動か手動か
     if(upedge_share(msg->buttons[static_cast<int>(Buttons::Share)])){
-        auto msg_autonomous = std::make_shared<std_msgs::msg::Bool>();
+        auto msg_autonomous = std::make_unique<std_msgs::msg::Bool>();
         msg_autonomous->data = is_autonomous = !is_autonomous;
-        publisher_autonomous->publish(*msg_autonomous);
-        RCLCPP_INFO(this->get_logger(), "自動フラグ : %d", msg_autonomous->data);
+        publisher_autonomous->publish(std::move(msg_autonomous));
+        RCLCPP_INFO(this->get_logger(), "自動フラグ : %d", is_autonomous);
     }
     // リスタート
     if(upedge_options(msg->buttons[static_cast<int>(Buttons::Options)])){
-        publisher_restart->publish(*std::make_shared<std_msgs::msg::Empty>());
+        publisher_restart->publish(std::make_unique<std_msgs::msg::Empty>());
         RCLCPP_INFO(this->get_logger(), "再稼働");
     }
     // 経路選択
@@ -64,24 +64,24 @@ void Controller::_subscriber_callback_joy(const sensor_msgs::msg::Joy::SharedPtr
     }
     // レーン切り替え
     if(upedge_cross(msg->buttons[static_cast<int>(Buttons::Cross)])){
-        publisher_lane_switch_flag->publish(*std::make_shared<std_msgs::msg::Empty>());
+        publisher_lane_switch_flag->publish(std::make_unique<std_msgs::msg::Empty>());
         RCLCPP_INFO(this->get_logger(), "レーン切り替え");
     }
     // 手動の場合、速度指令値を送る
     if(!is_autonomous){
-        auto msg_vel = std::make_shared<steered_drive_msg::msg::SteeredDrive>();
+        auto msg_vel = std::make_unique<steered_drive_msg::msg::SteeredDrive>();
         msg_vel->velocity = linear_max_vel * msg->axes[static_cast<int>(Axes::L_y)];
         msg_vel->steering_angle = steering_max_angle * msg->axes[static_cast<int>(Axes::R_x)];
-        publisher_vel->publish(*msg_vel);
+        publisher_vel->publish(std::move(msg_vel));
     }
 
 }
 
 void Controller::publish_nav_cmd(const std::string& command){
-    auto msg_nav_cmd = std::make_shared<std_msgs::msg::String>();
+    auto msg_nav_cmd = std::make_unique<std_msgs::msg::String>();
     msg_nav_cmd->data = command;
-    publisher_nav_cmd->publish(*msg_nav_cmd);
-    RCLCPP_INFO(this->get_logger(), "経路選択 : %s", msg_nav_cmd->data.c_str());
+    publisher_nav_cmd->publish(std::move(msg_nav_cmd));
+    RCLCPP_INFO(this->get_logger(), "経路選択 : %s", command.c_str());
 }
 
 }  // namespace controller

--- a/control/trajectory_follower/include/trajectory_follower/controller_server.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/controller_server.hpp
@@ -34,13 +34,13 @@ public:
         const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
 private:
-    void path_callback(const nav_msgs::msg::Path::SharedPtr msg);
+    void path_callback(const nav_msgs::msg::Path::ConstSharedPtr msg);
     void pose_callback(
-        const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
+        const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg);
     void velocity_callback(
-        const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg);
-    void autonomous_callback(const std_msgs::msg::Bool::SharedPtr msg);
-    void caster_data_callback(const std_msgs::msg::Float64MultiArray::SharedPtr msg);
+        const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr msg);
+    void autonomous_callback(const std_msgs::msg::Bool::ConstSharedPtr msg);
+    void caster_data_callback(const std_msgs::msg::Float64MultiArray::ConstSharedPtr msg);
     void timer_callback();
 
     nav_msgs::msg::Path transform_path_to_base(
@@ -53,10 +53,10 @@ private:
     ControllerPlugin::SharedPtr plugin_;
 
     bool autonomous_flag_=false;
-    nav_msgs::msg::Path::SharedPtr path_;
-    geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr pose_;
-    geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr velocity_;
-    std_msgs::msg::Float64MultiArray::SharedPtr caster_data_;
+    nav_msgs::msg::Path::ConstSharedPtr path_;
+    geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr pose_;
+    geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr velocity_;
+    std_msgs::msg::Float64MultiArray::ConstSharedPtr caster_data_;
     std::optional<steered_drive_msg::msg::SteeredDrive> last_cmd_vel_;
     mutable std::mutex data_mutex_;
 

--- a/control/trajectory_follower/src/controller_server.cpp
+++ b/control/trajectory_follower/src/controller_server.cpp
@@ -51,7 +51,7 @@ ControllerServer::ControllerServer(
         std::bind(&ControllerServer::timer_callback, this));
 }
 
-void ControllerServer::autonomous_callback(const std_msgs::msg::Bool::SharedPtr msg)
+void ControllerServer::autonomous_callback(const std_msgs::msg::Bool::ConstSharedPtr msg)
 {
     std::lock_guard<std::mutex> lock(data_mutex_);
     if (msg->data && !autonomous_flag_) {
@@ -61,14 +61,14 @@ void ControllerServer::autonomous_callback(const std_msgs::msg::Bool::SharedPtr 
     autonomous_flag_ = msg->data;
 }
 
-void ControllerServer::path_callback(const nav_msgs::msg::Path::SharedPtr msg)
+void ControllerServer::path_callback(const nav_msgs::msg::Path::ConstSharedPtr msg)
 {
     std::lock_guard<std::mutex> lock(data_mutex_);
     path_ = msg;
 }
 
 void ControllerServer::pose_callback(
-    const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg)
+    const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg)
 {
     if (msg->header.frame_id != "map") {
         RCLCPP_WARN(
@@ -81,14 +81,14 @@ void ControllerServer::pose_callback(
 }
 
 void ControllerServer::velocity_callback(
-    const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg)
+    const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr msg)
 {
     std::lock_guard<std::mutex> lock(data_mutex_);
     velocity_ = msg;
 }
 
 void ControllerServer::caster_data_callback(
-    const std_msgs::msg::Float64MultiArray::SharedPtr msg)
+    const std_msgs::msg::Float64MultiArray::ConstSharedPtr msg)
 {
     std::lock_guard<std::mutex> lock(data_mutex_);
     caster_data_ = msg;
@@ -118,10 +118,10 @@ void ControllerServer::timer_callback()
         return;
     }
     if (!last_cmd_vel_) {
-        steered_drive_msg::msg::SteeredDrive stop_command;
-        stop_command.velocity = 0.0;
-        stop_command.steering_angle = 0.0;
-        command_publisher_->publish(stop_command);
+        auto stop_command = std::make_unique<steered_drive_msg::msg::SteeredDrive>();
+        stop_command->velocity = 0.0;
+        stop_command->steering_angle = 0.0;
+        command_publisher_->publish(std::move(stop_command));
     }
 
     const nav_msgs::msg::Path path_in_base = transform_path_to_base(*path_, *pose_);
@@ -135,8 +135,8 @@ void ControllerServer::timer_callback()
         RCLCPP_DEBUG(this->get_logger(), "コマンド計算に失敗しました");
         return;
     }
-    command_publisher_->publish(*command);
     last_cmd_vel_ = command;
+    command_publisher_->publish(std::make_unique<steered_drive_msg::msg::SteeredDrive>(*command));
 }
 
 nav_msgs::msg::Path ControllerServer::transform_path_to_base(

--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer_node.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer_node.hpp
@@ -25,8 +25,8 @@ class EkfLocalizerNode : public rclcpp::Node {
     explicit EkfLocalizerNode (const std::string &name_space, const rclcpp::NodeOptions &options = rclcpp::NodeOptions ());
 
    private:
-    void pf_pose_callback (const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
-    void velocity_callback (const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg);
+    void pf_pose_callback (const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg);
+    void velocity_callback (const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr msg);
     void predict_timer_callback ();
     void tf_timer_callback ();
 

--- a/localization/ekf_localizer/include/ekf_localizer/map_odom_tf_node.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/map_odom_tf_node.hpp
@@ -26,7 +26,7 @@ class MapOdomTfNode : public rclcpp::Node {
     explicit MapOdomTfNode (const std::string &name_space, const rclcpp::NodeOptions &options = rclcpp::NodeOptions ());
 
    private:
-    void localized_pose_callback (const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
+    void localized_pose_callback (const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg);
     void timer_callback ();
 
     const int         publish_period_ms_;

--- a/localization/ekf_localizer/include/ekf_localizer/odom_tf_node.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/odom_tf_node.hpp
@@ -26,8 +26,8 @@ class OdomTfNode : public rclcpp::Node {
     explicit OdomTfNode (const std::string &name_space, const rclcpp::NodeOptions &options = rclcpp::NodeOptions ());
 
    private:
-    void imu_callback (const sensor_msgs::msg::Imu::SharedPtr msg);
-    void velocity_callback (const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg);
+    void imu_callback (const sensor_msgs::msg::Imu::ConstSharedPtr msg);
+    void velocity_callback (const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr msg);
     void timer_callback ();
 
     void                                 integrate_velocity (const geometry_msgs::msg::TwistWithCovarianceStamped &velocity_msg, const rclcpp::Time &stamp);

--- a/localization/ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer.cpp
@@ -58,10 +58,8 @@ void EkfLocalizer::initialize (const double x, const double y, const double yaw,
     has_last_yaw_stamp_          = false;
 }
 
+// 共分散のclamp
 void EkfLocalizer::clamp_covariance_floor () {
-    // 停止継続時など同じ位置に一致し続けるPF観測により共分散が過剰に収縮すると、
-    // 直後の旋回・急発進のような正しい観測までMahalanobisゲートで弾かれ続ける
-    // ロック状態に陥る。下限を設けて防ぐ。
     covariance_ (0, 0) = std::max (covariance_ (0, 0), config_.min_position_variance);
     covariance_ (1, 1) = std::max (covariance_ (1, 1), config_.min_position_variance);
     covariance_ (2, 2) = std::max (covariance_ (2, 2), config_.min_yaw_variance);

--- a/localization/ekf_localizer/src/ekf_localizer_node.cpp
+++ b/localization/ekf_localizer/src/ekf_localizer_node.cpp
@@ -50,7 +50,7 @@ EkfLocalizerNode::EkfLocalizerNode (const std::string &name_space, const rclcpp:
     tf_timer_      = create_wall_timer (std::chrono::milliseconds (tf_interval_ms_), std::bind (&EkfLocalizerNode::tf_timer_callback, this));
 }
 
-void EkfLocalizerNode::pf_pose_callback (const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg) {
+void EkfLocalizerNode::pf_pose_callback (const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg) {
     const double       x   = msg->pose.pose.position.x;
     const double       y   = msg->pose.pose.position.y;
     const double       yaw = utils::yaw_from_quaternion (msg->pose.pose.orientation);
@@ -93,7 +93,7 @@ void EkfLocalizerNode::pf_pose_callback (const geometry_msgs::msg::PoseWithCovar
     }
 }
 
-void EkfLocalizerNode::velocity_callback (const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg) {
+void EkfLocalizerNode::velocity_callback (const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr msg) {
     // velocity_bodyはVN body系(x前 / y右 / z下)で来るのでREP-103へ直す。
     const geometry_msgs::msg::Twist twist = utils::vn_body_to_rep103 (msg->twist.twist);
 
@@ -147,7 +147,7 @@ void EkfLocalizerNode::tf_timer_callback () {
     if (!ekf_localizer_.initialized ()) {
         return;
     }
-    pose_publisher_->publish (ekf_localizer_.make_pose ("map"));
+    pose_publisher_->publish (std::make_unique<geometry_msgs::msg::PoseWithCovarianceStamped> (ekf_localizer_.make_pose ("map")));
 }
 
 }  // namespace ekf_localizer

--- a/localization/ekf_localizer/src/map_odom_tf_node.cpp
+++ b/localization/ekf_localizer/src/map_odom_tf_node.cpp
@@ -26,7 +26,7 @@ MapOdomTfNode::MapOdomTfNode (const std::string &name_space, const rclcpp::NodeO
     timer_ = create_wall_timer (std::chrono::milliseconds (publish_period_ms_), std::bind (&MapOdomTfNode::timer_callback, this));
 }
 
-void MapOdomTfNode::localized_pose_callback (const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg) {
+void MapOdomTfNode::localized_pose_callback (const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg) {
     geometry_msgs::msg::TransformStamped odom_to_base;
     try {
         odom_to_base = tf_buffer_->lookupTransform ("odom", "base_link", tf2::TimePointZero);

--- a/localization/ekf_localizer/src/odom_tf_node.cpp
+++ b/localization/ekf_localizer/src/odom_tf_node.cpp
@@ -44,7 +44,7 @@ OdomTfNode::OdomTfNode (const std::string &name_space, const rclcpp::NodeOptions
     timer_                 = create_wall_timer (std::chrono::milliseconds (publish_period_ms_), std::bind (&OdomTfNode::timer_callback, this));
 }
 
-void OdomTfNode::imu_callback (const sensor_msgs::msg::Imu::SharedPtr msg) {
+void OdomTfNode::imu_callback (const sensor_msgs::msg::Imu::ConstSharedPtr msg) {
     const double imu_yaw = normalize_angle (HALF_PI + utils::yaw_from_quaternion (msg->orientation));
     if (!std::isfinite (imu_yaw)) {
         RCLCPP_WARN_THROTTLE (get_logger (), *get_clock (), 1000, "IMUのyawが非有限値のため無視する");
@@ -62,7 +62,7 @@ void OdomTfNode::imu_callback (const sensor_msgs::msg::Imu::SharedPtr msg) {
     }
 }
 
-void OdomTfNode::velocity_callback (const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg) {
+void OdomTfNode::velocity_callback (const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr msg) {
     const rclcpp::Time          stamp (msg->header.stamp, get_clock ()->get_clock_type ());
     std::lock_guard<std::mutex> lock (data_mutex_);
     if (!has_initial_imu_yaw_) {
@@ -126,7 +126,7 @@ void OdomTfNode::timer_callback () {
     }
 
     tf_broadcaster_->sendTransform (transform);
-    odom_publisher_->publish (odometry);
+    odom_publisher_->publish (std::make_unique<nav_msgs::msg::Odometry> (std::move (odometry)));
 }
 
 geometry_msgs::msg::TransformStamped OdomTfNode::make_transform (const rclcpp::Time &stamp) const {

--- a/localization/pose_estimater/include/pose_estimater/pose_estimater_node.hpp
+++ b/localization/pose_estimater/include/pose_estimater/pose_estimater_node.hpp
@@ -31,12 +31,12 @@ class PoseEstimaterNode : public rclcpp::Node {
     explicit PoseEstimaterNode (const std::string &name_space, const rclcpp::NodeOptions &options = rclcpp::NodeOptions ());
 
    private:
-    void lane_line_points_callback (const sensor_msgs::msg::PointCloud2::SharedPtr msg);
-    void vector_map_callback (const vectormap_msgs::msg::VectorMap::SharedPtr msg);
-    void gnss_callback (const sensor_msgs::msg::NavSatFix::SharedPtr msg);
-    void imu_callback (const sensor_msgs::msg::Imu::SharedPtr msg);
-    void velocity_callback (const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg);
-    void initial_pose_callback (const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
+    void lane_line_points_callback (const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
+    void vector_map_callback (const vectormap_msgs::msg::VectorMap::ConstSharedPtr msg);
+    void gnss_callback (const sensor_msgs::msg::NavSatFix::ConstSharedPtr msg);
+    void imu_callback (const sensor_msgs::msg::Imu::ConstSharedPtr msg);
+    void velocity_callback (const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr msg);
+    void initial_pose_callback (const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg);
     void timer_callback ();
 
     void rebuild_map_points (const vectormap_msgs::msg::VectorMap &map_msg);
@@ -61,14 +61,14 @@ class PoseEstimaterNode : public rclcpp::Node {
     const double      imu_yaw_variance_;
     ParticleFilter    particle_filter_;
 
-    std::shared_ptr<const PfTargetMap>                        map_points_;
-    sensor_msgs::msg::PointCloud2::SharedPtr                  latest_lane_line_points_;
-    sensor_msgs::msg::NavSatFix::SharedPtr                    latest_gnss_msg_;
-    sensor_msgs::msg::Imu::SharedPtr                          latest_imu_msg_;
-    geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr latest_velocity_msg_;
-    geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr  pending_initial_pose_;
-    std::mutex                                                data_mutex_;
-    sensor_msgs::msg::PointCloud2::SharedPtr                  processed_lane_line_points_;
+    std::shared_ptr<const PfTargetMap>                             map_points_;
+    sensor_msgs::msg::PointCloud2::ConstSharedPtr                  latest_lane_line_points_;
+    sensor_msgs::msg::NavSatFix::ConstSharedPtr                    latest_gnss_msg_;
+    sensor_msgs::msg::Imu::ConstSharedPtr                          latest_imu_msg_;
+    geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr latest_velocity_msg_;
+    geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr  pending_initial_pose_;
+    std::mutex                                                     data_mutex_;
+    sensor_msgs::msg::PointCloud2::ConstSharedPtr                  processed_lane_line_points_;
 
     rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr                  lane_line_points_subscription_;
     rclcpp::Subscription<vectormap_msgs::msg::VectorMap>::SharedPtr                 vector_map_subscription_;

--- a/localization/pose_estimater/src/particle_filter.cpp
+++ b/localization/pose_estimater/src/particle_filter.cpp
@@ -128,8 +128,7 @@ void ParticleFilter::set_particles_for_test (std::vector<Particle> particles) {
 void ParticleFilter::predict (const double linear_velocity, const double yaw_rate, const double dt) {
     const double delta_s   = linear_velocity * dt;
     const double delta_yaw = yaw_rate * dt;
-    // emcl2 の OdomModel と同じスケーリング。分散が |Δs|・|Δθ| に線形なので
-    // 累積拡散はステップ分割数(タイマー周期)に依らない。
+
     const double fw_std  = std::sqrt (config_.odom_fw_dev_per_fw * config_.odom_fw_dev_per_fw * std::abs (delta_s) + config_.odom_fw_dev_per_rot * config_.odom_fw_dev_per_rot * std::abs (delta_yaw));
     const double rot_std = std::sqrt (config_.odom_rot_dev_per_fw * config_.odom_rot_dev_per_fw * std::abs (delta_s) + config_.odom_rot_dev_per_rot * config_.odom_rot_dev_per_rot * std::abs (delta_yaw));
 
@@ -206,12 +205,6 @@ void ParticleFilter::update_weights (const std::vector<Eigen::Vector2d> &source_
     const double inv_two_sigma_sq = 1.0 / (2.0 * config_.likelihood_dev * config_.likelihood_dev);
     const double inv_point_count  = 1.0 / static_cast<double> (source_points_base_link.size ());
 
-    // 対応距離を超えた点は距離を上限で打ち切って一定の罰を与える。無罰にすると
-    // 地図から外れた点が増えるほど罰の総和が減り、車線幅ぶんずれた姿勢が
-    // 真値より高い尤度を得てしまう。
-    // さらに観測点数で正規化し、実効的な尤度の鋭さを likelihood_dev だけで
-    // 決まるようにする。点数ぶん累積すると実効σが σ/√N まで縮み、
-    // initialize() のばら撒き幅とスケールが合わなくなる。
     std::vector<double> log_likelihoods (particles_.size ());
     for (std::size_t i = 0U; i < particles_.size (); ++i) {
         const Particle &particle = particles_[i];
@@ -235,8 +228,6 @@ void ParticleFilter::update_weights (const std::vector<Eigen::Vector2d> &source_
 
     const double best_log_likelihood = *std::max_element (log_likelihoods.begin (), log_likelihoods.end ());
 
-    // 最良値を引いてからexpするのでアンダーフローしない。最良パーティクルの係数は
-    // 常に1になるため weight_sum は必ず正になる。
     double weight_sum = 0.0;
     for (std::size_t i = 0U; i < particles_.size (); ++i) {
         particles_[i].weight *= std::exp (log_likelihoods[i] - best_log_likelihood);
@@ -246,8 +237,6 @@ void ParticleFilter::update_weights (const std::vector<Eigen::Vector2d> &source_
         particle.weight /= weight_sum;
     }
 
-    // 見失いは最良パーティクルのRMS残差で判定する。ESS比は重みの偏りしか測らないため、
-    // 全パーティクルが同程度に地図から外れている状態を検出できない。
     const double best_rms_residual = std::sqrt (-best_log_likelihood / inv_two_sigma_sq);
     if (best_rms_residual > config_.reinit_residual_threshold) {
         ++lost_streak_;
@@ -293,8 +282,7 @@ PoseEstimate2D ParticleFilter::estimate () const {
         const double yaw_delta = normalize_angle (particle.yaw - result.yaw);
         yaw_variance += normalized_weight * yaw_delta * yaw_delta;
     }
-    // リサンプルで粒子が潰れると分散が実際の推定誤差より桁違いに小さく出る。
-    // 下限を設けて、EKF側が観測を過信して利得1で追従してしまうのを防ぐ。
+
     result.position_covariance        = position_covariance;
     result.position_covariance (0, 0) = std::max (result.position_covariance (0, 0), config_.min_position_variance);
     result.position_covariance (1, 1) = std::max (result.position_covariance (1, 1), config_.min_position_variance);

--- a/localization/pose_estimater/src/pose_estimater_node.cpp
+++ b/localization/pose_estimater/src/pose_estimater_node.cpp
@@ -103,8 +103,11 @@ PoseEstimaterNode::PoseEstimaterNode(const std::string& name_space, const rclcpp
       gnss_position_variance_(get_parameter("gnss_position_variance").as_double()),
       imu_yaw_variance_(get_parameter("imu_yaw_variance").as_double()),
       particle_filter_(make_particle_filter_config(*this), std::random_device{}()) {
+    rclcpp::SubscriptionOptions no_intra_process_options;
+    no_intra_process_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+
     lane_line_points_subscription_ = this->create_subscription<sensor_msgs::msg::PointCloud2>("/perception/lane_line_points", rclcpp::SensorDataQoS().keep_last(1), std::bind(&PoseEstimaterNode::lane_line_points_callback, this, std::placeholders::_1));
-    vector_map_subscription_       = this->create_subscription<vectormap_msgs::msg::VectorMap>("/vector_map", rclcpp::QoS(1).transient_local(), std::bind(&PoseEstimaterNode::vector_map_callback, this, std::placeholders::_1));
+    vector_map_subscription_       = this->create_subscription<vectormap_msgs::msg::VectorMap>("/vector_map", rclcpp::QoS(1).transient_local(), std::bind(&PoseEstimaterNode::vector_map_callback, this, std::placeholders::_1), no_intra_process_options);
     gnss_subscription_             = this->create_subscription<sensor_msgs::msg::NavSatFix>("/vectornav/gnss", rclcpp::SensorDataQoS().keep_last(1), std::bind(&PoseEstimaterNode::gnss_callback, this, std::placeholders::_1));
     imu_subscription_              = this->create_subscription<sensor_msgs::msg::Imu>("/vectornav/imu", rclcpp::SensorDataQoS().keep_last(1), std::bind(&PoseEstimaterNode::imu_callback, this, std::placeholders::_1));
     velocity_subscription_         = this->create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>("/vectornav/velocity_body", rclcpp::SensorDataQoS().keep_last(1), std::bind(&PoseEstimaterNode::velocity_callback, this, std::placeholders::_1));

--- a/localization/pose_estimater/src/pose_estimater_node.cpp
+++ b/localization/pose_estimater/src/pose_estimater_node.cpp
@@ -118,31 +118,31 @@ PoseEstimaterNode::PoseEstimaterNode(const std::string& name_space, const rclcpp
     timer_                         = this->create_wall_timer(std::chrono::milliseconds(interval_ms_), std::bind(&PoseEstimaterNode::timer_callback, this));
 }
 
-void PoseEstimaterNode::lane_line_points_callback(const sensor_msgs::msg::PointCloud2::SharedPtr msg) {
+void PoseEstimaterNode::lane_line_points_callback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg) {
     std::lock_guard<std::mutex> lock(data_mutex_);
     latest_lane_line_points_ = msg;
 }
 
-void PoseEstimaterNode::vector_map_callback(const vectormap_msgs::msg::VectorMap::SharedPtr msg) {
+void PoseEstimaterNode::vector_map_callback(const vectormap_msgs::msg::VectorMap::ConstSharedPtr msg) {
     rebuild_map_points(*msg);
 }
 
-void PoseEstimaterNode::gnss_callback(const sensor_msgs::msg::NavSatFix::SharedPtr msg) {
+void PoseEstimaterNode::gnss_callback(const sensor_msgs::msg::NavSatFix::ConstSharedPtr msg) {
     std::lock_guard<std::mutex> lock(data_mutex_);
     latest_gnss_msg_ = msg;
 }
 
-void PoseEstimaterNode::imu_callback(const sensor_msgs::msg::Imu::SharedPtr msg) {
+void PoseEstimaterNode::imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg) {
     std::lock_guard<std::mutex> lock(data_mutex_);
     latest_imu_msg_ = msg;
 }
 
-void PoseEstimaterNode::velocity_callback(const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg) {
+void PoseEstimaterNode::velocity_callback(const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr msg) {
     std::lock_guard<std::mutex> lock(data_mutex_);
     latest_velocity_msg_ = msg;
 }
 
-void PoseEstimaterNode::initial_pose_callback(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg) {
+void PoseEstimaterNode::initial_pose_callback(const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg) {
     std::lock_guard<std::mutex> lock(data_mutex_);
     pending_initial_pose_ = msg;
 }
@@ -219,30 +219,30 @@ void PoseEstimaterNode::publish_particle_pose_array(const builtin_interfaces::ms
         return;
     }
 
-    geometry_msgs::msg::PoseArray pose_array;
-    pose_array.header.stamp    = stamp;
-    pose_array.header.frame_id = "map";
-    const auto& particles      = particle_filter_.particles();
-    pose_array.poses.reserve(particles.size());
+    auto pose_array = std::make_unique<geometry_msgs::msg::PoseArray>();
+    pose_array->header.stamp    = stamp;
+    pose_array->header.frame_id = "map";
+    const auto& particles       = particle_filter_.particles();
+    pose_array->poses.reserve(particles.size());
     for (const auto& particle : particles) {
         geometry_msgs::msg::Pose pose;
         pose.position.x  = particle.x;
         pose.position.y  = particle.y;
         pose.position.z  = 0.0;
         pose.orientation = utils::yaw_to_quaternion(particle.yaw);
-        pose_array.poses.push_back(pose);
+        pose_array->poses.push_back(pose);
     }
-    particle_pose_array_publisher_->publish(pose_array);
+    particle_pose_array_publisher_->publish(std::move(pose_array));
 }
 
 void PoseEstimaterNode::timer_callback() {
     // lockを短時間保持するために、必要なデータをコピーしてから処理する。
-    sensor_msgs::msg::PointCloud2::SharedPtr                  lane_line_points_msg;
-    sensor_msgs::msg::NavSatFix::SharedPtr                    gnss_msg;
-    sensor_msgs::msg::Imu::SharedPtr                          imu_msg;
-    geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr velocity_msg;
-    geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr  initial_pose_msg;
-    std::shared_ptr<const PfTargetMap>                        map_points;
+    sensor_msgs::msg::PointCloud2::ConstSharedPtr                  lane_line_points_msg;
+    sensor_msgs::msg::NavSatFix::ConstSharedPtr                    gnss_msg;
+    sensor_msgs::msg::Imu::ConstSharedPtr                          imu_msg;
+    geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr velocity_msg;
+    geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr  initial_pose_msg;
+    std::shared_ptr<const PfTargetMap>                             map_points;
     {
         std::lock_guard<std::mutex> lock(data_mutex_);
         lane_line_points_msg = latest_lane_line_points_;
@@ -255,10 +255,11 @@ void PoseEstimaterNode::timer_callback() {
     }
 
     if (initial_pose_msg) {
-        initial_pose_msg->header.frame_id = "map";
-        initial_pose_msg->header.stamp    = this->get_clock()->now();
-        initialize_particle_filter(*initial_pose_msg);
-        pf_pose_publisher_->publish(*initial_pose_msg);
+        auto initial_pose = std::make_unique<geometry_msgs::msg::PoseWithCovarianceStamped>(*initial_pose_msg);
+        initial_pose->header.frame_id = "map";
+        initial_pose->header.stamp    = this->get_clock()->now();
+        initialize_particle_filter(*initial_pose);
+        pf_pose_publisher_->publish(std::move(initial_pose));
         return;
     }
 
@@ -272,11 +273,11 @@ void PoseEstimaterNode::timer_callback() {
         }
         if (!map_points || map_points->empty()) {
             RCLCPP_DEBUG(this->get_logger(), "Vector mapを待機中");
-            pf_pose_publisher_->publish(raw_pose);
+            pf_pose_publisher_->publish(std::make_unique<geometry_msgs::msg::PoseWithCovarianceStamped>(raw_pose));
             return;
         }
         initialize_particle_filter(raw_pose);
-        pf_pose_publisher_->publish(raw_pose);
+        pf_pose_publisher_->publish(std::make_unique<geometry_msgs::msg::PoseWithCovarianceStamped>(raw_pose));
         publish_particle_pose_array(raw_pose.header.stamp);
         return;
     }
@@ -309,7 +310,7 @@ void PoseEstimaterNode::timer_callback() {
         }
     }
 
-    pf_pose_publisher_->publish(make_pose(estimate_stamp, particle_filter_.estimate()));
+    pf_pose_publisher_->publish(std::make_unique<geometry_msgs::msg::PoseWithCovarianceStamped>(make_pose(estimate_stamp, particle_filter_.estimate())));
     publish_particle_pose_array(estimate_stamp);
 }
 

--- a/main_executor/src/main.cpp
+++ b/main_executor/src/main.cpp
@@ -22,6 +22,7 @@ int main(int argc, char * argv[]){
     rclcpp::NodeOptions nodes_option;
     nodes_option.allow_undeclared_parameters(true);
     nodes_option.automatically_declare_parameters_from_overrides(true);
+    nodes_option.use_intra_process_comms(true);
     const bool use_sim = rclcpp::Node("launch", nodes_option).get_parameter("sim").as_bool();
 
     if (use_sim) {

--- a/map/vectormap_server/src/vectormap_server_node.cpp
+++ b/map/vectormap_server/src/vectormap_server_node.cpp
@@ -30,10 +30,13 @@ VectormapServerNode::VectormapServerNode(
     marker_array_ = create_vector_map_marker_array(map_msg_);
     static_tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(this);
 
+    rclcpp::PublisherOptions no_intra_process_options;
+    no_intra_process_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+
     vectormap_publisher_ = this->create_publisher<vectormap_msgs::msg::VectorMap>(
-        "vector_map", rclcpp::QoS(1).transient_local());
+        "vector_map", rclcpp::QoS(1).transient_local(), no_intra_process_options);
     vectormap_visualize_marker_publisher = this->create_publisher<visualization_msgs::msg::MarkerArray>(
-        "vector_map/visualize", rclcpp::QoS(1).transient_local());
+        "vector_map/visualize", rclcpp::QoS(1).transient_local(), no_intra_process_options);
 
     publish_static_transforms();
     publish_map();

--- a/perception/lane_line_publisher/include/lane_line_publisher/ground_projection.hpp
+++ b/perception/lane_line_publisher/include/lane_line_publisher/ground_projection.hpp
@@ -25,9 +25,9 @@ struct GroundProjectionLUT
 {
     int width = 0;
     int height = 0;
-    int row_begin = 0;  // 有効な行の開始
-    int row_end = 0;    // 有効な行の終端
-    std::vector<Eigen::Vector2d> points;  // size = (row_end-row_begin)*width, 無効セルはNaN
+    int row_begin = 0;
+    int row_end = 0;
+    std::vector<Eigen::Vector2d> points;  // size:(row_end-row_begin)*width
 
     bool try_get(int row, int col, Eigen::Vector2d& out) const;
 };

--- a/perception/lane_line_publisher/include/lane_line_publisher/lane_line_publisher_node.hpp
+++ b/perception/lane_line_publisher/include/lane_line_publisher/lane_line_publisher_node.hpp
@@ -29,12 +29,12 @@ public:
         const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
 
 private:
-    void lane_mask_callback(const sensor_msgs::msg::Image::SharedPtr msg);
+    void lane_mask_callback(const sensor_msgs::msg::Image::ConstSharedPtr msg);
 
-    sensor_msgs::msg::PointCloud2 make_lane_line_point_cloud(
+    sensor_msgs::msg::PointCloud2::UniquePtr make_lane_line_point_cloud(
         const std::vector<Eigen::Vector2d>& base_points,
         const builtin_interfaces::msg::Time& stamp) const;
-    visualization_msgs::msg::MarkerArray make_lane_line_marker_array(
+    visualization_msgs::msg::MarkerArray::UniquePtr make_lane_line_marker_array(
         const std::vector<Eigen::Vector2d>& base_points,
         const builtin_interfaces::msg::Time& stamp) const;
 

--- a/perception/lane_line_publisher/include/lane_line_publisher/vectormap_visualizer_node.hpp
+++ b/perception/lane_line_publisher/include/lane_line_publisher/vectormap_visualizer_node.hpp
@@ -29,8 +29,8 @@ public:
         const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
 
 private:
-    void image_callback(const sensor_msgs::msg::Image::SharedPtr msg);
-    void vector_map_callback(const visualization_msgs::msg::MarkerArray::SharedPtr msg);
+    void image_callback(const sensor_msgs::msg::Image::ConstSharedPtr msg);
+    void vector_map_callback(const visualization_msgs::msg::MarkerArray::ConstSharedPtr msg);
 
     const camera_utility::CameraIntrinsics camera_intrinsics_;
     const tf2::Transform base_T_camera_;

--- a/perception/lane_line_publisher/src/lane_line_publisher_node.cpp
+++ b/perception/lane_line_publisher/src/lane_line_publisher_node.cpp
@@ -59,7 +59,7 @@ void LaneLinePublisherNode::lane_mask_callback(const sensor_msgs::msg::Image::Co
     const auto base_points = voxel_downsample(observed_points, voxel_grid_size_meter_);
 
     lane_line_points_publisher_->publish(make_lane_line_point_cloud(base_points, msg->header.stamp));
-    // マーカーはrviz用途のみなので、購読者がいないときは組み立てもしない
+    // debug用のため，subscriberがいない場合はpublishしない
     if (lane_line_marker_publisher_->get_subscription_count() > 0) {
         lane_line_marker_publisher_->publish(make_lane_line_marker_array(base_points, msg->header.stamp));
     }

--- a/perception/lane_line_publisher/src/lane_line_publisher_node.cpp
+++ b/perception/lane_line_publisher/src/lane_line_publisher_node.cpp
@@ -41,7 +41,7 @@ LaneLinePublisherNode::LaneLinePublisherNode(
         "/perception/lane_line", rclcpp::QoS(10));
 }
 
-void LaneLinePublisherNode::lane_mask_callback(const sensor_msgs::msg::Image::SharedPtr msg)
+void LaneLinePublisherNode::lane_mask_callback(const sensor_msgs::msg::Image::ConstSharedPtr msg)
 {
     cv::Mat skeleton_mask;
     const auto mask_image = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::MONO8);
@@ -59,27 +59,30 @@ void LaneLinePublisherNode::lane_mask_callback(const sensor_msgs::msg::Image::Sh
     const auto base_points = voxel_downsample(observed_points, voxel_grid_size_meter_);
 
     lane_line_points_publisher_->publish(make_lane_line_point_cloud(base_points, msg->header.stamp));
-    lane_line_marker_publisher_->publish(make_lane_line_marker_array(base_points, msg->header.stamp));
+    // マーカーはrviz用途のみなので、購読者がいないときは組み立てもしない
+    if (lane_line_marker_publisher_->get_subscription_count() > 0) {
+        lane_line_marker_publisher_->publish(make_lane_line_marker_array(base_points, msg->header.stamp));
+    }
 }
 
-sensor_msgs::msg::PointCloud2 LaneLinePublisherNode::make_lane_line_point_cloud(
+sensor_msgs::msg::PointCloud2::UniquePtr LaneLinePublisherNode::make_lane_line_point_cloud(
     const std::vector<Eigen::Vector2d>& base_points,
     const builtin_interfaces::msg::Time& stamp) const
 {
-    sensor_msgs::msg::PointCloud2 cloud;
-    cloud.header.stamp = stamp;
-    cloud.header.frame_id = "base_link";
-    cloud.height = 1;
-    cloud.is_dense = true;
-    cloud.is_bigendian = false;
+    auto cloud = std::make_unique<sensor_msgs::msg::PointCloud2>();
+    cloud->header.stamp = stamp;
+    cloud->header.frame_id = "base_link";
+    cloud->height = 1;
+    cloud->is_dense = true;
+    cloud->is_bigendian = false;
 
-    sensor_msgs::PointCloud2Modifier modifier(cloud);
+    sensor_msgs::PointCloud2Modifier modifier(*cloud);
     modifier.setPointCloud2FieldsByString(1, "xyz");
     modifier.resize(base_points.size());
 
-    sensor_msgs::PointCloud2Iterator<float> iter_x(cloud, "x");
-    sensor_msgs::PointCloud2Iterator<float> iter_y(cloud, "y");
-    sensor_msgs::PointCloud2Iterator<float> iter_z(cloud, "z");
+    sensor_msgs::PointCloud2Iterator<float> iter_x(*cloud, "x");
+    sensor_msgs::PointCloud2Iterator<float> iter_y(*cloud, "y");
+    sensor_msgs::PointCloud2Iterator<float> iter_z(*cloud, "z");
     for (const auto& p : base_points) {
         *iter_x = static_cast<float>(p.x());
         *iter_y = static_cast<float>(p.y());
@@ -92,17 +95,17 @@ sensor_msgs::msg::PointCloud2 LaneLinePublisherNode::make_lane_line_point_cloud(
     return cloud;
 }
 
-visualization_msgs::msg::MarkerArray LaneLinePublisherNode::make_lane_line_marker_array(
+visualization_msgs::msg::MarkerArray::UniquePtr LaneLinePublisherNode::make_lane_line_marker_array(
     const std::vector<Eigen::Vector2d>& base_points,
     const builtin_interfaces::msg::Time& stamp) const
 {
-    visualization_msgs::msg::MarkerArray marker_array;
+    auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
 
     visualization_msgs::msg::Marker delete_marker;
     delete_marker.header.stamp = stamp;
     delete_marker.header.frame_id = "base_link";
     delete_marker.action = visualization_msgs::msg::Marker::DELETEALL;
-    marker_array.markers.push_back(delete_marker);
+    marker_array->markers.push_back(delete_marker);
 
     visualization_msgs::msg::Marker points_marker;
     points_marker.header = delete_marker.header;
@@ -127,7 +130,7 @@ visualization_msgs::msg::MarkerArray LaneLinePublisherNode::make_lane_line_marke
         points_marker.points.push_back(point);
     }
 
-    marker_array.markers.push_back(std::move(points_marker));
+    marker_array->markers.push_back(std::move(points_marker));
     return marker_array;
 }
 

--- a/perception/lane_line_publisher/src/vectormap_visualizer_node.cpp
+++ b/perception/lane_line_publisher/src/vectormap_visualizer_node.cpp
@@ -42,13 +42,13 @@ VectormapVisualizerNode::VectormapVisualizerNode(
 }
 
 void VectormapVisualizerNode::vector_map_callback(
-    const visualization_msgs::msg::MarkerArray::SharedPtr msg)
+    const visualization_msgs::msg::MarkerArray::ConstSharedPtr msg)
 {
     std::lock_guard<std::mutex> lock(vector_map_mutex_);
     latest_vector_map_markers_ = *msg;
 }
 
-void VectormapVisualizerNode::image_callback(const sensor_msgs::msg::Image::SharedPtr msg)
+void VectormapVisualizerNode::image_callback(const sensor_msgs::msg::Image::ConstSharedPtr msg)
 {
     if (vectormap_visualize_publisher_->get_subscription_count() == 0) {
         return;
@@ -86,8 +86,10 @@ void VectormapVisualizerNode::image_callback(const sensor_msgs::msg::Image::Shar
             vector_map_markers, base_T_map, base_T_camera_, camera_intrinsics_);
         draw_projected_line_strings(image, projected_line_strings);
 
-        vectormap_visualize_publisher_->publish(
-            *cv_bridge::CvImage(msg->header, sensor_msgs::image_encodings::BGR8, image).toImageMsg());
+        auto visualize_msg = std::make_unique<sensor_msgs::msg::Image>();
+        cv_bridge::CvImage(msg->header, sensor_msgs::image_encodings::BGR8, image)
+            .toImageMsg(*visualize_msg);
+        vectormap_visualize_publisher_->publish(std::move(visualize_msg));
     } catch (const std::exception& error) {
         RCLCPP_WARN_THROTTLE(
             this->get_logger(), *this->get_clock(), 1000,

--- a/perception/lane_line_publisher/src/vectormap_visualizer_node.cpp
+++ b/perception/lane_line_publisher/src/vectormap_visualizer_node.cpp
@@ -29,9 +29,13 @@ VectormapVisualizerNode::VectormapVisualizerNode(
     image_subscription_ = this->create_subscription<sensor_msgs::msg::Image>(
         "/zed/zed_node/rgb/image_rect_color", rclcpp::QoS(10),
         std::bind(&VectormapVisualizerNode::image_callback, this, std::placeholders::_1));
+    rclcpp::SubscriptionOptions no_intra_process_options;
+    no_intra_process_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+
     vector_map_subscription_ = this->create_subscription<visualization_msgs::msg::MarkerArray>(
         "/vector_map/visualize", rclcpp::QoS(1).transient_local(),
-        std::bind(&VectormapVisualizerNode::vector_map_callback, this, std::placeholders::_1));
+        std::bind(&VectormapVisualizerNode::vector_map_callback, this, std::placeholders::_1),
+        no_intra_process_options);
 
     vectormap_visualize_publisher_ = this->create_publisher<sensor_msgs::msg::Image>(
         "/perception/vectormap_visualize", rclcpp::QoS(10));

--- a/perception/object_detector/include/object_detector/object_detector_node.hpp
+++ b/perception/object_detector/include/object_detector/object_detector_node.hpp
@@ -27,7 +27,7 @@ public:
         const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
 
 private:
-    void pointcloud_callback(const sensor_msgs::msg::PointCloud2::SharedPtr msg);
+    void pointcloud_callback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
     void publish_empty(const rclcpp::Time& stamp);
 
     const double ground_z_threshold_m_;

--- a/perception/object_detector/src/object_detector_node.cpp
+++ b/perception/object_detector/src/object_detector_node.cpp
@@ -59,7 +59,7 @@ ObjectDetectorNode::ObjectDetectorNode(
         "/perception/objects_visualize", qos);
 }
 
-void ObjectDetectorNode::pointcloud_callback(const sensor_msgs::msg::PointCloud2::SharedPtr msg)
+void ObjectDetectorNode::pointcloud_callback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
     RCLCPP_DEBUG(
         get_logger(),
@@ -251,19 +251,25 @@ void ObjectDetectorNode::pointcloud_callback(const sensor_msgs::msg::PointCloud2
         ++id;
     }
 
-    objects_publisher_->publish(objects_msg);
-    marker_publisher_->publish(marker_array);
+    objects_publisher_->publish(
+        std::make_unique<object_detection_msgs::msg::ObjectInfoArray>(std::move(objects_msg)));
+    // マーカーはrviz用途のみ
+    if (marker_publisher_->get_subscription_count() > 0) {
+        marker_publisher_->publish(
+            std::make_unique<visualization_msgs::msg::MarkerArray>(std::move(marker_array)));
+    }
 }
 
 void ObjectDetectorNode::publish_empty(const rclcpp::Time& stamp)
 {
-    object_detection_msgs::msg::ObjectInfoArray objects_msg;
-    objects_msg.header.stamp = stamp;
-    objects_msg.header.frame_id = "map";
-    objects_publisher_->publish(objects_msg);
+    auto objects_msg = std::make_unique<object_detection_msgs::msg::ObjectInfoArray>();
+    objects_msg->header.stamp = stamp;
+    objects_msg->header.frame_id = "map";
+    objects_publisher_->publish(std::move(objects_msg));
 
-    visualization_msgs::msg::MarkerArray marker_array;
-    marker_publisher_->publish(marker_array);
+    if (marker_publisher_->get_subscription_count() > 0) {
+        marker_publisher_->publish(std::make_unique<visualization_msgs::msg::MarkerArray>());
+    }
 }
 
 }

--- a/planning/local_planner/include/local_planner/local_planner_server.hpp
+++ b/planning/local_planner/include/local_planner/local_planner_server.hpp
@@ -29,10 +29,10 @@ public:
         const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
 
 private:
-    void global_path_callback(const nav_msgs::msg::Path::SharedPtr msg);
-    void pose_callback(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
-    void velocity_callback(const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg);
-    void objects_callback(const object_detection_msgs::msg::ObjectInfoArray::SharedPtr msg);
+    void global_path_callback(const nav_msgs::msg::Path::ConstSharedPtr msg);
+    void pose_callback(const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg);
+    void velocity_callback(const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr msg);
+    void objects_callback(const object_detection_msgs::msg::ObjectInfoArray::ConstSharedPtr msg);
     void timer_callback();
 
     pluginlib::ClassLoader<LocalPlannerPlugin> plugin_loader_;
@@ -41,9 +41,9 @@ private:
     const int interval_ms_;
     const rclcpp::QoS qos_;
 
-    geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr pose_;
-    geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr velocity_;
-    object_detection_msgs::msg::ObjectInfoArray::SharedPtr objects_;
+    geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr pose_;
+    geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr velocity_;
+    object_detection_msgs::msg::ObjectInfoArray::ConstSharedPtr objects_;
     mutable std::mutex data_mutex_;
 
     rclcpp::Subscription<nav_msgs::msg::Path>::SharedPtr global_path_subscription_;

--- a/planning/local_planner/src/local_planner_server.cpp
+++ b/planning/local_planner/src/local_planner_server.cpp
@@ -43,28 +43,28 @@ LocalPlannerServer::LocalPlannerServer(
         std::bind(&LocalPlannerServer::timer_callback, this));
 }
 
-void LocalPlannerServer::global_path_callback(const nav_msgs::msg::Path::SharedPtr msg)
+void LocalPlannerServer::global_path_callback(const nav_msgs::msg::Path::ConstSharedPtr msg)
 {
     std::lock_guard<std::mutex> lock(data_mutex_);
     plugin_->setGlobalPath(*msg);
 }
 
 void LocalPlannerServer::pose_callback(
-    const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg)
+    const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg)
 {
     std::lock_guard<std::mutex> lock(data_mutex_);
     pose_ = msg;
 }
 
 void LocalPlannerServer::velocity_callback(
-    const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg)
+    const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr msg)
 {
     std::lock_guard<std::mutex> lock(data_mutex_);
     velocity_ = msg;
 }
 
 void LocalPlannerServer::objects_callback(
-    const object_detection_msgs::msg::ObjectInfoArray::SharedPtr msg)
+    const object_detection_msgs::msg::ObjectInfoArray::ConstSharedPtr msg)
 {
     std::lock_guard<std::mutex> lock(data_mutex_);
     objects_ = msg;
@@ -92,7 +92,7 @@ void LocalPlannerServer::timer_callback()
         RCLCPP_DEBUG(get_logger(), "ローカル経路の計算に失敗しました");
         return;
     }
-    local_path_publisher_->publish(*result);
+    local_path_publisher_->publish(std::make_unique<nav_msgs::msg::Path>(std::move(*result)));
 }
 
 }

--- a/planning/mission_planner/include/mission_planner/mission_planner_node.hpp
+++ b/planning/mission_planner/include/mission_planner/mission_planner_node.hpp
@@ -54,10 +54,10 @@ public:
     };
 
 private:
-    void vector_map_callback(const vectormap_msgs::msg::VectorMap::SharedPtr msg);
-    void pose_callback(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
-    void navigation_command_callback(const std_msgs::msg::String::SharedPtr msg);
-    void lane_change_callback(const std_msgs::msg::Empty::SharedPtr msg);
+    void vector_map_callback(const vectormap_msgs::msg::VectorMap::ConstSharedPtr msg);
+    void pose_callback(const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg);
+    void navigation_command_callback(const std_msgs::msg::String::ConstSharedPtr msg);
+    void lane_change_callback(const std_msgs::msg::Empty::ConstSharedPtr msg);
     void timer_callback();
 
     void build_map_lookup(const vectormap_msgs::msg::VectorMap& map_msg);
@@ -70,7 +70,7 @@ private:
         std::size_t& fallback_count) const;
     std::unordered_set<uint64_t> build_reachable_lanelet_set() const;
     std::pair<uint64_t, double> find_nearest_lanelet_within_route(const Point2D& point) const;
-    nav_msgs::msg::Path make_global_path_message(const rclcpp::Time& stamp) const;
+    nav_msgs::msg::Path::UniquePtr make_global_path_message(const rclcpp::Time& stamp) const;
     void report_curvature_qa() const;
 
     const int update_period_ms_;
@@ -97,7 +97,7 @@ private:
     std::unordered_map<uint64_t, uint64_t> left_adjacent_lanelet_by_id_;
     std::unordered_map<uint64_t, uint64_t> right_adjacent_lanelet_by_id_;
 
-    geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr latest_pose_;
+    geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr latest_pose_;
     mutable std::mutex data_mutex_;
 
     rclcpp::Subscription<vectormap_msgs::msg::VectorMap>::SharedPtr vector_map_subscription_;

--- a/planning/mission_planner/src/mission_planner_node.cpp
+++ b/planning/mission_planner/src/mission_planner_node.cpp
@@ -159,7 +159,7 @@ MissionPlannerNode::MissionPlannerNode(
 }
 
 void MissionPlannerNode::vector_map_callback(
-    const vectormap_msgs::msg::VectorMap::SharedPtr msg)
+    const vectormap_msgs::msg::VectorMap::ConstSharedPtr msg)
 {
     std::lock_guard<std::mutex> lock(data_mutex_);
     if (map_ready_) {
@@ -169,13 +169,13 @@ void MissionPlannerNode::vector_map_callback(
 }
 
 void MissionPlannerNode::pose_callback(
-    const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg)
+    const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr msg)
 {
     std::lock_guard<std::mutex> lock(data_mutex_);
     latest_pose_ = msg;
 }
 
-void MissionPlannerNode::navigation_command_callback(const std_msgs::msg::String::SharedPtr msg)
+void MissionPlannerNode::navigation_command_callback(const std_msgs::msg::String::ConstSharedPtr msg)
 {
     const auto requested_turn = parse_navigation_command(msg->data);
     if (!requested_turn) {
@@ -200,7 +200,7 @@ void MissionPlannerNode::navigation_command_callback(const std_msgs::msg::String
     global_path_publisher_->publish(make_global_path_message(now()));
 }
 
-void MissionPlannerNode::lane_change_callback(const std_msgs::msg::Empty::SharedPtr)
+void MissionPlannerNode::lane_change_callback(const std_msgs::msg::Empty::ConstSharedPtr)
 {
     std::lock_guard<std::mutex> lock(data_mutex_);
     if (!global_path_ready_ || !latest_pose_) {
@@ -308,21 +308,21 @@ void MissionPlannerNode::timer_callback()
     }
 }
 
-nav_msgs::msg::Path MissionPlannerNode::make_global_path_message(
+nav_msgs::msg::Path::UniquePtr MissionPlannerNode::make_global_path_message(
     const rclcpp::Time& stamp) const
 {
-    nav_msgs::msg::Path path;
-    path.header.stamp = stamp;
-    path.header.frame_id = "map";
-    path.poses.reserve(global_samples_.size());
+    auto path = std::make_unique<nav_msgs::msg::Path>();
+    path->header.stamp = stamp;
+    path->header.frame_id = "map";
+    path->poses.reserve(global_samples_.size());
     for (const auto& point : global_samples_) {
         geometry_msgs::msg::PoseStamped pose;
-        pose.header = path.header;
+        pose.header = path->header;
         pose.pose.position.x = point.x;
         pose.pose.position.y = point.y;
         pose.pose.position.z = 0.0;
         pose.pose.orientation = utils::yaw_to_quaternion(point.yaw);
-        path.poses.push_back(pose);
+        path->poses.push_back(pose);
     }
     return path;
 }

--- a/planning/mission_planner/src/mission_planner_node.cpp
+++ b/planning/mission_planner/src/mission_planner_node.cpp
@@ -130,10 +130,14 @@ MissionPlannerNode::MissionPlannerNode(
   current_route_is_loop_(false),
   last_navigation_command_turn_(read_default_navigation_command(*this))
 {
+    rclcpp::SubscriptionOptions no_intra_process_options;
+    no_intra_process_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+
     vector_map_subscription_ = create_subscription<vectormap_msgs::msg::VectorMap>(
         "/vector_map",
         rclcpp::QoS(1).transient_local(),
-        std::bind(&MissionPlannerNode::vector_map_callback, this, std::placeholders::_1));
+        std::bind(&MissionPlannerNode::vector_map_callback, this, std::placeholders::_1),
+        no_intra_process_options);
     pose_subscription_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
         "/localization/pose",
         rclcpp::SensorDataQoS().keep_last(1),

--- a/sensing/zed_wrapper/src/zed_wrapper_node.cpp
+++ b/sensing/zed_wrapper/src/zed_wrapper_node.cpp
@@ -101,7 +101,7 @@ void ZedWrapperNode::grab_callback()
 
     const rclcpp::Time stamp = now();
 
-    // 購読者がいない間はretrieve+memcpy自体を行わない（画像0.9MB／点群3.7MBの丸損を避ける）
+    // subscriberがいない場合は処理しない
     if (image_publisher_->get_subscription_count() > 0) {
         sl::Mat left_image;
         implementation_->zed.retrieveImage(left_image, sl::VIEW::LEFT, sl::MEM::CPU, implementation_->publish_resolution);
@@ -119,6 +119,7 @@ void ZedWrapperNode::grab_callback()
         image_publisher_->publish(std::move(msg));
     }
 
+    // subscriberがいない場合は処理しない
     if (pointcloud_publisher_->get_subscription_count() > 0) {
         sl::Mat pc_mat;
         implementation_->zed.retrieveMeasure(pc_mat, sl::MEASURE::XYZRGBA, sl::MEM::CPU, implementation_->publish_resolution);

--- a/sensing/zed_wrapper/src/zed_wrapper_node.cpp
+++ b/sensing/zed_wrapper/src/zed_wrapper_node.cpp
@@ -101,48 +101,51 @@ void ZedWrapperNode::grab_callback()
 
     const rclcpp::Time stamp = now();
 
-    sl::Mat left_image;
-    implementation_->zed.retrieveImage(left_image, sl::VIEW::LEFT, sl::MEM::CPU, implementation_->publish_resolution);
-    {
-        sensor_msgs::msg::Image msg;
-        msg.header.stamp    = stamp;
-        msg.header.frame_id = "camera_depth_link";
-        msg.width    = static_cast<uint32_t>(left_image.getWidth());
-        msg.height   = static_cast<uint32_t>(left_image.getHeight());
-        msg.encoding = "bgra8";
-        msg.step     = static_cast<uint32_t>(left_image.getStepBytes());
-        const size_t nbytes = msg.height * msg.step;
-        msg.data.resize(nbytes);
-        std::memcpy(msg.data.data(), left_image.getPtr<sl::uchar1>(), nbytes);
-        image_publisher_->publish(msg);
+    // 購読者がいない間はretrieve+memcpy自体を行わない（画像0.9MB／点群3.7MBの丸損を避ける）
+    if (image_publisher_->get_subscription_count() > 0) {
+        sl::Mat left_image;
+        implementation_->zed.retrieveImage(left_image, sl::VIEW::LEFT, sl::MEM::CPU, implementation_->publish_resolution);
+
+        auto msg = std::make_unique<sensor_msgs::msg::Image>();
+        msg->header.stamp    = stamp;
+        msg->header.frame_id = "camera_depth_link";
+        msg->width    = static_cast<uint32_t>(left_image.getWidth());
+        msg->height   = static_cast<uint32_t>(left_image.getHeight());
+        msg->encoding = "bgra8";
+        msg->step     = static_cast<uint32_t>(left_image.getStepBytes());
+        const size_t nbytes = msg->height * msg->step;
+        msg->data.resize(nbytes);
+        std::memcpy(msg->data.data(), left_image.getPtr<sl::uchar1>(), nbytes);
+        image_publisher_->publish(std::move(msg));
     }
 
-    sl::Mat pc_mat;
-    implementation_->zed.retrieveMeasure(pc_mat, sl::MEASURE::XYZRGBA, sl::MEM::CPU, implementation_->publish_resolution);
-    {
-        sensor_msgs::msg::PointCloud2 msg;
-        msg.header.stamp    = stamp;
-        msg.header.frame_id = "camera_depth_link";
-        msg.height     = static_cast<uint32_t>(pc_mat.getHeight());
-        msg.width      = static_cast<uint32_t>(pc_mat.getWidth());
-        msg.is_dense   = false;
-        msg.point_step = 16;
-        msg.row_step   = msg.point_step * msg.width;
+    if (pointcloud_publisher_->get_subscription_count() > 0) {
+        sl::Mat pc_mat;
+        implementation_->zed.retrieveMeasure(pc_mat, sl::MEASURE::XYZRGBA, sl::MEM::CPU, implementation_->publish_resolution);
 
-        msg.fields.resize(4);
-        msg.fields[0].name = "x";    msg.fields[0].offset = 0;
-        msg.fields[1].name = "y";    msg.fields[1].offset = 4;
-        msg.fields[2].name = "z";    msg.fields[2].offset = 8;
-        msg.fields[3].name = "rgba"; msg.fields[3].offset = 12;
-        for (auto & f : msg.fields) {
+        auto msg = std::make_unique<sensor_msgs::msg::PointCloud2>();
+        msg->header.stamp    = stamp;
+        msg->header.frame_id = "camera_depth_link";
+        msg->height     = static_cast<uint32_t>(pc_mat.getHeight());
+        msg->width      = static_cast<uint32_t>(pc_mat.getWidth());
+        msg->is_dense   = false;
+        msg->point_step = 16;
+        msg->row_step   = msg->point_step * msg->width;
+
+        msg->fields.resize(4);
+        msg->fields[0].name = "x";    msg->fields[0].offset = 0;
+        msg->fields[1].name = "y";    msg->fields[1].offset = 4;
+        msg->fields[2].name = "z";    msg->fields[2].offset = 8;
+        msg->fields[3].name = "rgba"; msg->fields[3].offset = 12;
+        for (auto & f : msg->fields) {
             f.datatype = sensor_msgs::msg::PointField::FLOAT32;
             f.count    = 1;
         }
 
-        const size_t nbytes = static_cast<size_t>(msg.height) * msg.row_step;
-        msg.data.resize(nbytes);
-        std::memcpy(msg.data.data(), pc_mat.getPtr<sl::uchar1>(), nbytes);
-        pointcloud_publisher_->publish(msg);
+        const size_t nbytes = static_cast<size_t>(msg->height) * msg->row_step;
+        msg->data.resize(nbytes);
+        std::memcpy(msg->data.data(), pc_mat.getPtr<sl::uchar1>(), nbytes);
+        pointcloud_publisher_->publish(std::move(msg));
     }
 }
 


### PR DESCRIPTION
### 概要

- #242 の修正です

### 変更点
- main.cppに該当node_optionを追加した
- trancient_local使用箇所にintra_processから外すoptionを追加した
  - jazzyはtrancient_localとintra_processが共存できるようですが、foxyとhumbleは共存できないようです
- publisher側を基本的にunique_ptrのmoveを使うようにした
- subscriber側はConstSharedPtrを使うようにした